### PR TITLE
Update set outputs to latest specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       id: gofmt
       run: |
         gofmt -w .
-        echo ::set-output name=formatted_files::$(git status -s -uno | wc -l)
+        echo "formatted_files=$(git status -s -uno | wc -l)" >> $GITHUB_OUTPUT
 
     - name: push formatting fixes
       if: steps.gofmt.outputs.formatted_files > 0
@@ -62,8 +62,16 @@ jobs:
       run: go mod download
 
     - name: run tests
-      if: ${{ matrix.os }} != "windows-latest"
+      id: tests
       env:
         # unauthenticated calls have lower limits than authenticated ones
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: go test -v -race ${{ matrix.coverageArgs }} ./...
+
+    - name: run tests with inputs
+      env:
+        ACTIONS_OUTPUT_SET: "true"
+        # unauthenticated calls have lower limits than authenticated ones
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        my_output: "${{ steps.tests.outputs.my-output }}"
+      run: go test -v -run TestOutputTasks ./core/...

--- a/core/command.go
+++ b/core/command.go
@@ -48,7 +48,7 @@ func IssueCommand(kind string, properties map[string]string, message string) {
 // issueFileCommand implements stores the command in a file
 // see https://github.com/actions/toolkit/pull/571/files#diff-9ce6eb99f5fb5529e795254801e03ae56d67d3d5fcbec635f91e9a8a61ad8b64R10
 func issueFileCommand(command string, message string) error {
-	path, ok := os.LookupEnv("GITHUB_" + command)
+	path, ok := os.LookupEnv(command)
 	if ok {
 		fd, err := os.OpenFile(path, os.O_RDWR, 0)
 		if err != nil {
@@ -57,7 +57,7 @@ func issueFileCommand(command string, message string) error {
 		fmt.Fprintln(fd, message)
 		return nil
 	}
-	return fmt.Errorf("unable to find command file GITHUB_%s", command)
+	return fmt.Errorf("unable to find command file %s", command)
 }
 
 type command struct {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,10 +1,32 @@
 package core
 
 import (
+	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestFormatOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("This test only runs on unix with \\n line separator")
+	}
+	assert.Equal(t, "my-name<<_GitHubActionsGoFileCommandDelimeter_\nmy-value\n_GitHubActionsGoFileCommandDelimeter_\n", formatOutput("my-name", "my-value"))
+}
+
+func TestOutputTasks(t *testing.T) {
+	if _, ok := os.LookupEnv("ACTIONS_OUTPUT_SET"); ok {
+		// state is only available in pre and post actions:
+		// https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#sending-values-to-the-pre-and-post-actions
+		// assert.Equal(t, "my-state-value", GetState("my-state"))
+		assert.Equal(t, "my-output-value", os.Getenv("my_output"))
+		assert.Equal(t, "my-env-value", os.Getenv("my_env"))
+	}
+	SaveState("my-state", "my-state-value")
+	ExportVariable("my_env", "my-env-value")
+	SetOutput("my-output", "my-output-value")
+}
 
 func TestGetInput(t *testing.T) {
 	t.Run("when environment variable is not net", func(t *testing.T) {

--- a/github/context.go
+++ b/github/context.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/actions-go/toolkit/core"
 	"github.com/google/go-github/v42/github"
 )
 
@@ -79,15 +80,18 @@ type ActionRepo struct {
 
 // ActionContext contains details on the workflow execution
 type ActionContext struct {
-	Payload   WebhookPayload
-	EventName string
-	SHA       string
-	Ref       string
-	Workflow  string
-	Action    string
-	Actor     string
-	Issue     ActionIssue
-	Repo      ActionRepo
+	Payload           WebhookPayload
+	EventName         string
+	SHA               string
+	Ref               string
+	Workflow          string
+	Action            string
+	Actor             string
+	Issue             ActionIssue
+	Repo              ActionRepo
+	OutputFilePath    string
+	StateFilePath     string
+	ExportEnvFilePath string
 }
 
 func noGitHubEvent(path string) {
@@ -109,13 +113,16 @@ func ParseActionEnv() ActionContext {
 		Repo:  getIndex(r, 1),
 	}
 	ctx := ActionContext{
-		EventName: os.Getenv("GITHUB_EVENT_NAME"),
-		SHA:       os.Getenv("GITHUB_SHA"),
-		Ref:       os.Getenv("GITHUB_REF"),
-		Workflow:  os.Getenv("GITHUB_WORKFLOW"),
-		Action:    os.Getenv("GITHUB_ACTION"),
-		Actor:     os.Getenv("GITHUB_ACTOR"),
-		Repo:      repo,
+		EventName:         os.Getenv("GITHUB_EVENT_NAME"),
+		SHA:               os.Getenv("GITHUB_SHA"),
+		Ref:               os.Getenv("GITHUB_REF"),
+		Workflow:          os.Getenv("GITHUB_WORKFLOW"),
+		Action:            os.Getenv("GITHUB_ACTION"),
+		Actor:             os.Getenv("GITHUB_ACTOR"),
+		OutputFilePath:    os.Getenv(core.GitHubOutputFilePathEnvName),
+		StateFilePath:     os.Getenv(core.GitHubStateFilePathEnvName),
+		ExportEnvFilePath: os.Getenv(core.GitHubExportEnvFilePathEnvName),
+		Repo:              repo,
 		Issue: ActionIssue{
 			Owner: repo.Owner,
 			Repo:  repo.Repo,


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ and https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files